### PR TITLE
feat: execute FileType autocmd to make sure treesitter is loaded.

### DIFF
--- a/lua/jupytext.lua
+++ b/lua/jupytext.lua
@@ -124,6 +124,7 @@ M.setup = function(opts)
       end
 
       vim.cmd.doautocmd({ args = { 'BufReadPost', ipynb_file }, mods = { emsg_silent = true } })
+      vim.api.nvim_exec_autocmds('FileType', { buffer = bufnr })
     end,
   })
 


### PR DESCRIPTION
With the introduction of the `nvim-treesitter` `main` branch (which is now the actively maintained branch, replacing the abandoned `master` branch), the recommended method for initializing Treesitter is to invoke it manually via a `FileType` autocmd event.

The following example demonstrates their current recommendation:
https://github.com/nvim-treesitter/nvim-treesitter/tree/main?tab=readme-ov-file#highlighting:

```lua
vim.api.nvim_create_autocmd('FileType', {
  pattern = { 'python', 'markdown' },
  callback = function() vim.treesitter.start() end,
})
```

However, Treesitter fails to activate when an `ipynb` file is converted to a `.py` or `.markdown` file. The primary reason for this is that the `FileType` event is not triggered during the conversion process.

This PR addresses the issue by manually triggering the `FileType` event at the end of the jupytext's `BufReadCmd` autocmd event, ensuring that Treesitter is correctly activated.